### PR TITLE
chore: remove faker.random. deprecation warnings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,5 +3,5 @@ import RandExp from 'randexp'
 
 export const seed = (value: number) => {
   Faker.seed.call(Faker, value)
-  RandExp.prototype.randInt = (from, to) => Faker.random.number({ min: from, max: to })
+  RandExp.prototype.randInt = (from, to) => Faker.datatype.number({ min: from, max: to })
 }

--- a/src/fake.ts
+++ b/src/fake.ts
@@ -1,4 +1,4 @@
-import { random } from 'faker'
+import { datatype } from 'faker'
 import { AnySchema } from 'yup'
 import { BaseFaker, typeToFaker } from './fakers/base'
 import { MixedFaker } from './fakers/mixed'
@@ -12,7 +12,7 @@ export function rootFake<Schema extends AnySchema>(schema: Schema, options: Opti
     return (schema as any).getValue(undefined, options?.parent, options.context)
   }
   if (isLazy(schema)) {
-    if (random.float({ min: 0, max: 1 }) > 0.1) return undefined as any
+    if (datatype.float({ min: 0, max: 1 }) > 0.1) return undefined as any
     return rootFake(schema.resolve({}), options)
   }
   if ((schema as any).conditions.length) {

--- a/src/fakers/array.ts
+++ b/src/fakers/array.ts
@@ -1,5 +1,5 @@
 import { mixed, array } from 'yup'
-import { random } from 'faker'
+import { datatype } from 'faker'
 import { MixedFaker } from './mixed'
 import { addFaker } from './base'
 
@@ -19,7 +19,7 @@ export class ArrayFaker extends MixedFaker<ArraySchema<AnySchema>> {
       ((this.schema.tests.find(test => test.OPTIONS.name === 'max')?.OPTIONS.params?.max as number) || undefined) ??
       min + 10
 
-    const array = Array(random.number({ min, max })).fill(null)
+    const array = Array(datatype.number({ min, max })).fill(null)
     const innerSchema = this.schema.innerType
     if (innerSchema) {
       return array.map(() => ArrayFaker.rootFake(this.schema.innerType!, options))

--- a/src/fakers/base.ts
+++ b/src/fakers/base.ts
@@ -1,4 +1,4 @@
-import { random } from 'faker'
+import { datatype } from 'faker'
 import { isSchema } from 'yup'
 
 import type { AnySchema } from 'yup'
@@ -45,7 +45,7 @@ export abstract class BaseFaker<Schema extends AnySchema> {
 
   protected fakeUndefined(): [boolean, any?] {
     if (
-      random.float({ min: 0, max: 1 }) > 0.8 &&
+      datatype.float({ min: 0, max: 1 }) > 0.8 &&
       this.schema.tests.some(test => ['required', 'defined'].includes(test.OPTIONS.name!)) === false
     )
       return [true, undefined]
@@ -55,7 +55,7 @@ export abstract class BaseFaker<Schema extends AnySchema> {
 
   protected fakeNullable(): [boolean, any?] {
     if (
-      random.float({ min: 0, max: 1 }) > 0.8 &&
+      datatype.float({ min: 0, max: 1 }) > 0.8 &&
       this.schema.spec.nullable &&
       this.schema.tests.some(test => test.OPTIONS.name === 'required') === false
     )
@@ -66,7 +66,7 @@ export abstract class BaseFaker<Schema extends AnySchema> {
 
   protected fakeOneOf(): [boolean, any?] {
     const oneOf = this.schema.describe().oneOf
-    if (oneOf.length) return [true, oneOf[random.number({ min: 0, max: oneOf.length - 1 })]]
+    if (oneOf.length) return [true, oneOf[datatype.number({ min: 0, max: oneOf.length - 1 })]]
 
     return [false]
   }

--- a/src/fakers/boolean.ts
+++ b/src/fakers/boolean.ts
@@ -1,5 +1,5 @@
 import { boolean } from 'yup'
-import { random } from 'faker'
+import { datatype } from 'faker'
 import { MixedFaker } from './mixed'
 import { fakeDedicatedTest, addFaker } from './base'
 
@@ -7,7 +7,7 @@ import type { BooleanSchema } from 'yup'
 
 export class BooleanFaker extends MixedFaker<BooleanSchema> {
   doFake() {
-    return random.boolean()
+    return datatype.boolean()
   }
 }
 

--- a/src/fakers/mixed.ts
+++ b/src/fakers/mixed.ts
@@ -1,4 +1,4 @@
-import { random } from 'faker'
+import { datatype } from 'faker'
 import { boolean, number, string, date, mixed } from 'yup'
 import { BaseFaker, addFaker } from './base'
 
@@ -18,7 +18,7 @@ export class MixedFaker<Schema extends AnySchema> extends BaseFaker<Schema> {
   }
 
   doFake(options?: Options) {
-    let randomSchema = schemas[random.number({ min: 0, max: schemas.length - 1 })]
+    let randomSchema = schemas[datatype.number({ min: 0, max: schemas.length - 1 })]
 
     if (this.schema.tests.some(test => ['required', 'defined'].includes(test.OPTIONS.name!))) {
       randomSchema = randomSchema.required()

--- a/src/fakers/number.ts
+++ b/src/fakers/number.ts
@@ -1,5 +1,5 @@
 import { number } from 'yup'
-import { random } from 'faker'
+import { datatype } from 'faker'
 import { MixedFaker } from './mixed'
 import { addFaker } from './base'
 
@@ -26,11 +26,11 @@ export class NumberFaker extends MixedFaker<NumberSchema> {
     }
 
     return this.schema.tests.find(test => test.OPTIONS.name === 'integer')
-      ? random.number({
+      ? datatype.number({
           min: Math.ceil(min),
           max: Math.floor(max),
         })
-      : random.float({
+      : datatype.float({
           min,
           max,
           precision: 1 / 1e16,

--- a/src/fakers/object.ts
+++ b/src/fakers/object.ts
@@ -1,5 +1,5 @@
 import { mixed, object } from 'yup'
-import { random, lorem } from 'faker'
+import { datatype, lorem } from 'faker'
 import { MixedFaker } from './mixed'
 import { isReference } from '../util'
 import { addFaker } from './base'
@@ -30,7 +30,7 @@ export class ObjectFaker extends MixedFaker<ObjectSchema<any>> {
 
     const noUnknown = this.schema.spec.strict && this.schema.tests.some(test => test.OPTIONS.name === 'noUnknown')
     if (noUnknown === false) {
-      Array(random.number({ min: 10, max: 10 }))
+      Array(datatype.number({ min: 10, max: 10 }))
         .fill(null)
         .map(() => lorem.word())
         .filter(field => fields.includes(field) === false)

--- a/src/fakers/string.ts
+++ b/src/fakers/string.ts
@@ -1,5 +1,5 @@
 import { string } from 'yup'
-import { random, internet, lorem } from 'faker'
+import { random, datatype, internet, lorem } from 'faker'
 import { randexp } from 'randexp'
 import { MixedFaker } from './mixed'
 import { fakeDedicatedTest, addFaker } from './base'
@@ -20,7 +20,7 @@ export class StringFaker extends MixedFaker<StringSchema> {
     if (
       min === undefined &&
       this.schema.tests.some(test => test.OPTIONS.name === 'required') === false &&
-      random.float({ min: 0, max: 1 }) > 0.8
+      datatype.float({ min: 0, max: 1 }) > 0.8
     ) {
       return ''
     }
@@ -34,7 +34,7 @@ export class StringFaker extends MixedFaker<StringSchema> {
     if (shouldTrim) {
       result = result.trim() + random.alpha({ count: result.length })
     } else {
-      result = ' '.repeat(random.number(max ?? min ?? 3)) + result + ' '.repeat(random.number(max ?? min ?? 3))
+      result = ' '.repeat(datatype.number(max ?? min ?? 3)) + result + ' '.repeat(datatype.number(max ?? min ?? 3))
     }
 
     result = result.slice(0, max)
@@ -56,7 +56,7 @@ export class StringFaker extends MixedFaker<StringSchema> {
 addFaker(string, StringFaker)
 
 fakeDedicatedTest(string, 'uuid', () => {
-  return random.uuid()
+  return datatype.uuid()
 })
 
 fakeDedicatedTest(string, 'email', () => {


### PR DESCRIPTION
Using this module produces quite a lot of console logs because of deprecations in faker.
This just replaces those deprecations for new API.

```
 console.log
    Deprecation Warning: faker.random.number is now located in faker.datatype.number

      at Random.number (../node_modules/faker/lib/random.js:37:13)
          at Array.map (<anonymous>)
```